### PR TITLE
Asset API V1 to V2 API Transition

### DIFF
--- a/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
+++ b/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
@@ -29,7 +29,7 @@ namespace Kentico.Kontent.Management.Tests
         // New data recorded to file system with TestRunType.LiveEndPoint_SaveToFileSystem is placed to /bin/ folder
         // It needs to be synced to the /Data/ folder in the project
         // Copy to output directory = Copy always is automatically ensured by a wildcard in .csproj file
-        private static readonly TestUtils.TestRunType _runType = TestUtils.TestRunType.MockFromFileSystem;
+        private static readonly TestUtils.TestRunType _runType = TestUtils.TestRunType.LiveEndPoint;
 
 
         #region Helper methods and constants
@@ -971,6 +971,67 @@ namespace Kentico.Kontent.Management.Tests
             var response = await client.ListAssetsAsync();
             Assert.NotNull(response);
             Assert.NotNull(response.FirstOrDefault());
+        }
+
+        [Fact]
+        [Trait("Category", "Asset")]
+        public async void ListFolders_ListFolders()
+        {
+            var client = CreateManagementClient(nameof(ListFolders_ListFolders));
+
+            var response = await client.GetAssetFoldersAsync();
+            Assert.NotNull(response);
+            Assert.True(response.Folders.Count() > 0);
+        }
+
+        [Fact]
+        [Trait("Category", "Asset")]
+        public async void ListFolders_GetFolderLinkedTree()
+        {
+            var client = CreateManagementClient(nameof(ListFolders_GetFolderLinkedTree));
+
+            var response = await client.GetAssetFoldersAsync();
+            var linkedHierarchy = response.Folders.GetParentLinkedFolderHierarchy();
+
+            Assert.NotNull(response);
+            Assert.True(response.Folders.Count() > 0);
+        }
+
+
+        [Fact]
+        [Trait("Category", "Asset")]
+        public async void ListFolders_GetFolderLinkedTreeSearchByFolderId()
+        {
+            var client = CreateManagementClient(nameof(ListFolders_GetFolderLinkedTreeSearchByFolderId));
+
+            var response = await client.GetAssetFoldersAsync();
+            var linkedHierarchy = response.Folders.GetParentLinkedFolderHierarchy();
+            var result = linkedHierarchy.GetParentLinkedFolderHierarchyById("a5d2b6cd-928b-4623-bc5e-f3f63112d8fc"); //Go one level deep
+            var result2 = linkedHierarchy.GetParentLinkedFolderHierarchyById("52a474a9-606c-4157-8372-1a9edc5f3aeb"); //Go two levels deep
+            var result3 = linkedHierarchy.GetParentLinkedFolderHierarchyById("16a5bf3f-2600-4b97-822b-5e30092f5239"); //Go three levels deep
+            var result4 = linkedHierarchy.GetParentLinkedFolderHierarchyById("74bbdcc1-2591-4ba9-b9ee-f6027a8827b4"); //Go three levels deep
+            
+            Assert.NotNull(response);
+            Assert.NotNull(result);
+            Assert.NotNull(result2);
+            Assert.NotNull(result3);
+            Assert.NotNull(result4);
+        }
+
+        [Fact]
+        [Trait("Category", "Asset")]
+        public async void ListFolders_GetFolderPathString()
+        {
+            var client = CreateManagementClient(nameof(ListFolders_GetFolderPathString));
+
+            var response = await client.GetAssetFoldersAsync();
+            var linkedHierarchy = response.Folders.GetParentLinkedFolderHierarchy();
+            var result = linkedHierarchy.GetParentLinkedFolderHierarchyById("16a5bf3f-2600-4b97-822b-5e30092f5239"); //Go three levels deep
+            var pathString = result.GetFullFolderPath(); //Should be a folder path string \TopFolder\2ndFolder\3rdFolder (3 levels deep)
+
+            Assert.NotNull(response);
+            Assert.NotNull(result);
+            Assert.True(pathString == "\\TopFolder\\2ndFolder\\3rdFolder");
         }
 
         [Fact]

--- a/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
+++ b/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
@@ -29,7 +29,7 @@ namespace Kentico.Kontent.Management.Tests
         // New data recorded to file system with TestRunType.LiveEndPoint_SaveToFileSystem is placed to /bin/ folder
         // It needs to be synced to the /Data/ folder in the project
         // Copy to output directory = Copy always is automatically ensured by a wildcard in .csproj file
-        private static readonly TestUtils.TestRunType _runType = TestUtils.TestRunType.LiveEndPoint;
+        private static readonly TestUtils.TestRunType _runType = TestUtils.TestRunType.MockFromFileSystem;
 
 
         #region Helper methods and constants

--- a/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
+++ b/Kentico.Kontent.Management.Tests/ManagementClientTests.cs
@@ -1027,11 +1027,11 @@ namespace Kentico.Kontent.Management.Tests
             var response = await client.GetAssetFoldersAsync();
             var linkedHierarchy = response.Folders.GetParentLinkedFolderHierarchy();
             var result = linkedHierarchy.GetParentLinkedFolderHierarchyById("16a5bf3f-2600-4b97-822b-5e30092f5239"); //Go three levels deep
-            var pathString = result.GetFullFolderPath(); //Should be a folder path string \TopFolder\2ndFolder\3rdFolder (3 levels deep)
+            var pathString = result.GetFullFolderPath(); //Should be a folder path string TopFolder\2ndFolder\3rdFolder (3 levels deep)
 
             Assert.NotNull(response);
             Assert.NotNull(result);
-            Assert.True(pathString == "\\TopFolder\\2ndFolder\\3rdFolder");
+            Assert.True(pathString == "TopFolder\\2ndFolder\\3rdFolder");
         }
 
         [Fact]

--- a/Kentico.Kontent.Management.Tests/Mocks/FileSystemHttpClientMock.cs
+++ b/Kentico.Kontent.Management.Tests/Mocks/FileSystemHttpClientMock.cs
@@ -4,6 +4,7 @@ using Kentico.Kontent.Management.Modules.HttpClient;
 using Kentico.Kontent.Management.Modules.ResiliencePolicy;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
@@ -40,9 +41,10 @@ namespace Kentico.Kontent.Management.Tests.Mocks
             IMessageCreator messageCreator,
             string endpointUrl,
             HttpMethod method,
-            HttpContent content = null)
+            HttpContent content = null,
+            Dictionary<string, string> headers = null)
         {
-            var message = messageCreator.CreateMessage(method, endpointUrl, content);
+            var message = messageCreator.CreateMessage(method, endpointUrl, content, headers);
             var isFirst = _firstRequest;
             _firstRequest = false;
 

--- a/Kentico.Kontent.Management.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
+++ b/Kentico.Kontent.Management.Tests/Modules/ActionInvoker/ActionInvokerTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Kentico.Kontent.Management.Models.Assets;
 using Xunit;
+using System.Collections.Generic;
 
 namespace Kentico.Kontent.Management.Tests
 {
@@ -13,7 +14,7 @@ namespace Kentico.Kontent.Management.Tests
     {
         internal string requestBody;
 
-        public async Task<HttpResponseMessage> SendAsync(IMessageCreator messageCreator, string endpointUrl, HttpMethod method, HttpContent content = null)
+        public async Task<HttpResponseMessage> SendAsync(IMessageCreator messageCreator, string endpointUrl, HttpMethod method, HttpContent content = null, Dictionary<string, string> headers = null)
         {
             var message = messageCreator.CreateMessage(method, endpointUrl, content);
             requestBody = await message.Content.ReadAsStringAsync();

--- a/Kentico.Kontent.Management.Tests/TestUtils.cs
+++ b/Kentico.Kontent.Management.Tests/TestUtils.cs
@@ -23,9 +23,10 @@ namespace Kentico.Kontent.Management.Tests
                 var httpClient = new FileSystemHttpClientMock(options, saveToFileSystem, testName);
 
                 var urlBuilder = new EndpointUrlBuilder(options);
+                var urlBuilderv2 = new EndpointUrlBuilderV2(options);
                 var actionInvoker = new ActionInvoker(httpClient, new MessageCreator(options.ApiKey));
 
-                return new ManagementClient(urlBuilder, actionInvoker);
+                return new ManagementClient(urlBuilder, urlBuilderv2, actionInvoker);
             }
 
             return new ManagementClient(options);

--- a/Kentico.Kontent.Management/Configuration/ManagementOptions.cs
+++ b/Kentico.Kontent.Management/Configuration/ManagementOptions.cs
@@ -13,6 +13,11 @@ namespace Kentico.Kontent.Management
         public string Endpoint { get; set; } = "https://manage.kontent.ai/{0}";
 
         /// <summary>
+        /// Gets or sets the Production endpoint address for V2 management API. Optional, defaults to "https://manage.kontent.ai/v2/{0}".
+        /// </summary>
+        public string EndpointV2 { get; set; } = "https://manage.kontent.ai/v2/{0}";
+
+        /// <summary>
         /// Gets or sets the Project identifier.
         /// </summary>
         public string ProjectId { get; set; }

--- a/Kentico.Kontent.Management/ManagementClient.cs
+++ b/Kentico.Kontent.Management/ManagementClient.cs
@@ -354,7 +354,6 @@ namespace Kentico.Kontent.Management
         /// <returns>The <see cref="ListingResponseModel{AssetModel}"/> instance that represents the listing of assets.</returns>
         public async Task<ListingResponseModel<AssetModel>> ListAssetsAsync()
         {
-            //var endpointUrl = _urlBuilder.BuildAssetListingUrl();
             var endpointUrl = _urlBuilderV2.BuildAssetsUrl();
             var response = await _actionInvoker.InvokeReadOnlyMethodAsync<AssetListingResponseServerModel>(endpointUrl, HttpMethod.Get);
 

--- a/Kentico.Kontent.Management/ManagementClientExtensions.cs
+++ b/Kentico.Kontent.Management/ManagementClientExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using Kentico.Kontent.Management.Models.Assets;
@@ -128,7 +129,7 @@ namespace Kentico.Kontent.Management
 
             return response;
         }
-        
+
         /// <summary>
         /// Creates or updates the given asset.
         /// </summary>
@@ -218,6 +219,103 @@ namespace Kentico.Kontent.Management
             {
                 asset.Title = updatedAsset.Title;
             }
+        }
+
+        /// <summary>
+        /// Get Folder Hiearchy for a given folder Id
+        /// </summary>
+        /// <param name="folders">Folders</param>
+        /// <param name="folderId">Folder Id</param>
+        /// <returns></returns>
+        public static IEnumerable<AssetFolderHierarchy> GetFolderHierarchy(this IEnumerable<AssetFolderHierarchy> folders, string folderId)
+        {
+            if (folders == null)
+                return null;
+            //Recursively search for the folder hierarchy that an asset is in. Returns null if file is not in a folder.
+            var folderList = new List<AssetFolderHierarchy>();
+            foreach (var itm in folders)
+            {
+                if (itm.Id == folderId)
+                {
+                    folderList.Add(itm);
+                }
+                if (itm.Folders != null)
+                {
+                    itm.Folders.GetFolderHierarchy(folderId);
+                }
+            }
+            return folderList;
+        }
+
+        /// <summary>
+        /// Gets the full folder path string
+        /// </summary>
+        /// <param name="folder">Folder</param>
+        /// <returns></returns>
+        public static string GetFullFolderPath(this AssetFolderLinkingHierarchy folder)
+        {
+            List<string> folderName = new List<string>();
+            if (folder.Parent != null)
+                folderName.Add(GetFullFolderPath(folder.Parent));
+            folderName.Add(folder.Name);
+            return string.Join("\\", folderName);
+        }
+
+        /// <summary>
+        /// Gets the full path to a specific folder id so you can walk back up the parent linking tree
+        /// </summary>
+        /// <param name="folders">Folder</param>
+        /// <param name="folderId">Folder Id</param>
+        /// <returns></returns>
+        public static AssetFolderLinkingHierarchy GetParentLinkedFolderHierarchyById(this IEnumerable<AssetFolderLinkingHierarchy> folders, string folderId)
+        {
+            if (folders == null)
+                return null;
+            foreach (var folder in folders)
+            {
+                if (folder.Id == folderId)
+                    return folder;
+                else if (folder.Folders != null && folder.Folders.Count() > 0)
+                {
+                    var nestedFolder = folder.Folders.GetParentLinkedFolderHierarchyById(folderId);
+                    if (nestedFolder != null)
+                        return nestedFolder;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves a recursive linked list of folders with the parent property filled in
+        /// </summary>
+        /// <param name="folders">Folder list from Kentico Kontent</param>
+        /// <param name="parentLinked">Parent linked folder</param>
+        /// <returns></returns>
+        public static IEnumerable<AssetFolderLinkingHierarchy> GetParentLinkedFolderHierarchy(this IEnumerable<AssetFolderHierarchy> folders,
+            AssetFolderLinkingHierarchy parentLinked = null)
+        {
+            //Recursively search for the folder hierarchy that an asset is in. Returns null if file is not in a folder.
+            var folderList = new List<AssetFolderLinkingHierarchy>();
+            foreach (var itm in folders)
+            {
+                var newFolder = new AssetFolderLinkingHierarchy()
+                {
+                    ExternalId = itm.ExternalId,
+                    Folders = (itm.Folders != null && itm.Folders.Count() > 0) ? new List<AssetFolderLinkingHierarchy>() : null,
+                    Id = itm.Id,
+                    Name = itm.Name
+                };
+                if (itm.Folders != null)
+                {
+                    newFolder.Folders = itm.Folders.GetParentLinkedFolderHierarchy(newFolder);
+                }
+                if (parentLinked != null)
+                {
+                    newFolder.Parent = parentLinked;
+                }
+                folderList.Add(newFolder);
+            }
+            return folderList;
         }
     }
 }

--- a/Kentico.Kontent.Management/ManagementEndpointUrlBuilderV2.cs
+++ b/Kentico.Kontent.Management/ManagementEndpointUrlBuilderV2.cs
@@ -1,0 +1,185 @@
+﻿using Kentico.Kontent.Management.Models.Assets;
+using Kentico.Kontent.Management.Models.Items;
+using System;
+using System.Net;
+
+namespace Kentico.Kontent.Management
+{
+    internal sealed class EndpointUrlBuilderV2
+    {
+        private const int URI_MAX_LENGTH = 65519;
+
+        private const string URL_ITEM = "/items";
+        private const string URL_TEMPLATE_ITEM_ID = "/items/{0}";
+        private const string URL_TEMPLATE_ITEM_EXTERNAL_ID = "/items/external-id/{0}";
+        private const string URL_TEMPLATE_ITEM_CODENAME = "/items/codename/{0}";
+
+        private const string URL_VARIANT = "/variants";
+        private const string URL_TEMPLATE_VARIANT_ID = "/variants/{0}";
+        private const string URL_TEMPLATE_VARIANT_CODENAME = "/variants/codename/{0}";
+
+        private const string URL_ASSET = "/assets";
+        private const string URL_TEMPLATE_ASSET_ID = "/assets/{0}";
+        private const string URL_TEMPLATE_ASSET_EXTERNAL_ID = "/assets/external-id/{0}";
+
+        private const string URL_ASSET_FOLDERS = "/folders";
+
+        private const string URL_TEMPLATE_FILE_FILENAME = "/files/{0}";
+
+        private const string URL_VALIDATE = "/validate";
+
+        private readonly ManagementOptions _options;
+
+        internal EndpointUrlBuilderV2(ManagementOptions options)
+        {
+            _options = options;
+        }
+
+        #region Variants
+
+        internal string BuildListVariantsUrl(ContentItemIdentifier identifier)
+        {
+            var itemSegment = GetItemUrlSegment(identifier);
+
+            return GetUrl(string.Concat(itemSegment, URL_VARIANT));
+        }
+
+        internal string BuildVariantsUrl(ContentItemVariantIdentifier identifier)
+        {
+            var itemSegment = GetItemUrlSegment(identifier.ItemIdentifier);
+            var variantSegment = GetVariantUrlSegment(identifier.LanguageIdentifier);
+
+            return GetUrl(string.Concat(itemSegment, variantSegment));
+        }
+
+        private string GetVariantUrlSegment(LanguageIdentifier identifier)
+        {
+            if (!string.IsNullOrEmpty(identifier.Codename))
+            {
+                return string.Format(URL_TEMPLATE_VARIANT_CODENAME, identifier.Codename);
+            }
+
+            return string.Format(URL_TEMPLATE_VARIANT_ID, identifier.Id);
+        }
+
+        #endregion
+
+        #region Items
+
+        internal string BuildItemsUrl()
+        {
+            return GetUrl(URL_ITEM);
+        }
+
+        internal string BuildItemUrl(ContentItemIdentifier identifier)
+        {
+            var itemSegment = GetItemUrlSegment(identifier);
+            return GetUrl(itemSegment);
+        }
+
+        private string GetItemUrlSegment(ContentItemIdentifier identifier)
+        {
+            if (identifier.Id != null)
+            {
+                return string.Format(URL_TEMPLATE_ITEM_ID, identifier.Id);
+            }
+
+            if (!string.IsNullOrEmpty(identifier.Codename))
+            {
+                return string.Format(URL_TEMPLATE_ITEM_CODENAME, identifier.Codename);
+            }
+
+            if (!string.IsNullOrEmpty(identifier.ExternalId))
+            {
+                return BuildItemUrlSegmentFromExternalId(identifier.ExternalId);
+            }
+            throw new ArgumentException("You must provide item's id, codename or externalId");
+        }
+
+        internal string BuildItemUrlSegmentFromExternalId(string externalId)
+        {
+            var escapedExternalId = WebUtility.UrlEncode(externalId);
+            return string.Format(URL_TEMPLATE_ITEM_EXTERNAL_ID, escapedExternalId);
+        }
+
+        #endregion
+
+        #region Assets
+
+        public string BuildAssetsUrl()
+        {
+            return GetUrl(URL_ASSET);
+        }
+
+        public string BuildAssetFoldersUrl()
+        {
+            return GetUrl(URL_ASSET_FOLDERS);
+        }
+
+        public string BuildAssetsUrl(AssetIdentifier identifier)
+        {
+            if (identifier.Id != null)
+            {
+                return GetUrl(string.Format(URL_TEMPLATE_ASSET_ID, identifier.Id));
+            }
+
+            if (!string.IsNullOrEmpty(identifier.ExternalId))
+            {
+                return BuildAssetsUrlFromExternalId(identifier.ExternalId);
+            }
+
+            throw new ArgumentException("You must provide asset's id, or externalId");
+        }
+
+        public string BuildAssetsUrlFromExternalId(string externalId)
+        {
+            var escapedExternalId = WebUtility.UrlEncode(externalId);
+            return GetUrl(string.Format(URL_TEMPLATE_ASSET_EXTERNAL_ID, escapedExternalId));
+        }
+
+        #endregion
+
+        #region Binary files
+
+        public string BuildUploadFileUrl(string fileName)
+        {
+            return GetUrl(string.Format(URL_TEMPLATE_FILE_FILENAME, fileName));
+        }
+
+        #endregion
+
+        #region Validation
+
+        public string BuildValidationUrl()
+        {
+            return GetUrl(URL_VALIDATE);
+        }
+
+        #endregion
+
+        private string GetUrl(string path, params string[] parameters)
+        {
+            var projectSegment = $"projects/{_options.ProjectId}";
+
+            var endpointUrl = string.Format(_options.EndpointV2, projectSegment);
+            var url = string.Concat(endpointUrl, path);
+
+            if ((parameters != null) && (parameters.Length > 0))
+            {
+                var joinedQuery = string.Join("&", parameters);
+
+                if (!string.IsNullOrEmpty(joinedQuery))
+                {
+                    url = $"{url}?{joinedQuery}";
+                }
+            }
+
+            if (url.Length > URI_MAX_LENGTH)
+            {
+                throw new UriFormatException("The request url is too long. Split your query into multiple calls.");
+            }
+
+            return url;
+        }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetFolder.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetFolder.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Management.Models.Assets
+{
+    /// <summary>
+    /// Represents an asset folder
+    /// </summary>
+    public sealed class AssetFolder
+    {
+        /// <summary>
+        /// The referenced folder's ID. Not present if the asset is not in a folder.
+        /// </summary>
+        [JsonProperty("id", Required = Required.AllowNull)]
+        public string Id { get; set; }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetFolderHierarchy.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetFolderHierarchy.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Management.Models.Assets
+{
+    /// <summary>
+    /// Represents the Asset Folder Hiearchy (recursive)
+    /// </summary>
+    public sealed class AssetFolderHierarchy
+    {
+        /// <summary>
+        /// The referenced folder's ID. Not present if the asset is not in a folder. "00000000-0000-0000-0000-000000000000" means outside of any folder.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        /// <summary>
+        /// Gets external id of the identifier. The folder's external ID. Only present if specified when adding folders or modifying the folders collection to add new folders.
+        /// </summary>
+        [JsonProperty("external_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ExternalId { get; private set; }
+        /// <summary>
+        /// Name of the Folder
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        /// <summary>
+        /// Folders
+        /// </summary>
+        [JsonProperty("folders")]
+        public IEnumerable<AssetFolderHierarchy> Folders { get; set; }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetFolderIdentifier.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetFolderIdentifier.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Management.Models.Assets
+{
+    /// <summary>
+    /// Represents asset folder identifier.
+    /// </summary>
+    public sealed class AssetFolderIdentifier
+    {
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public AssetFolderIdentifier()
+        {
+            Id = new Guid("00000000-0000-0000-0000-000000000000"); //Default to the Guid that means "outside of any folder"
+        }
+
+        /// <summary>
+        /// Gets id of the identifier. "00000000-0000-0000-0000-000000000000" means outside of any folder.
+        /// </summary>
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Guid? Id { get; private set; }
+
+        /// <summary>
+        /// Gets external id of the identifier.
+        /// </summary>
+        [JsonProperty("external_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ExternalId { get; private set; }
+
+        /// <summary>
+        /// Creates identifier by id.
+        /// </summary>
+        /// <param name="id">The id of the identifier.</param>
+        public static AssetFolderIdentifier ById(Guid id)
+        {
+            return new AssetFolderIdentifier() { Id = id };
+        }
+
+        /// <summary>
+        /// Creates identifier by external id.
+        /// </summary>
+        /// <param name="externalId">The external id of the identifier.</param>
+        public static AssetFolderIdentifier ByExternalId(string externalId)
+        {
+            return new AssetFolderIdentifier() { ExternalId = externalId };
+        }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetFolderLinkingHierarchy.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetFolderLinkingHierarchy.cs
@@ -1,0 +1,40 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Management.Models.Assets
+{
+    /// <summary>
+    /// Represents the Asset Folder Hiearchy with parent folder traversal links. 
+    /// This class is a derivation of the AssetFolderHierarchy class. To receive an instance of this class <see cref="ManagementClientExtensions.GetParentLinkedFolderHierarchy"/>
+    /// </summary>
+    public sealed class AssetFolderLinkingHierarchy
+    {
+        /// <summary>
+        /// The referenced folder's ID. Not present if the asset is not in a folder. "00000000-0000-0000-0000-000000000000" means outside of any folder.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        /// <summary>
+        /// Gets external id of the identifier. The folder's external ID. Only present if specified when adding folders or modifying the folders collection to add new folders.
+        /// </summary>
+        [JsonProperty("external_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ExternalId { get; set; }
+        /// <summary>
+        /// Name of the Folder
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        /// <summary>
+        /// Folders
+        /// </summary>
+        [JsonProperty("folders")]
+        public IEnumerable<AssetFolderLinkingHierarchy> Folders { get; set; }
+        /// <summary>
+        /// Parent folder link
+        /// </summary>
+        [JsonIgnore()]
+        public AssetFolderLinkingHierarchy Parent { get; set; }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetFolderList.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetFolderList.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kentico.Kontent.Management.Models.Assets
+{
+    /// <summary>
+    /// Represents the asset folder list.
+    /// </summary>
+    public sealed class AssetFolderList
+    {
+        /// <summary>
+        /// Folder listing (recursive)
+        /// </summary>
+        [JsonProperty("folders")]
+        public IEnumerable<AssetFolderHierarchy> Folders { get; set; }
+        /// <summary>
+        /// Gets or sets the last modified timestamp of the asset.
+        /// </summary>
+        [JsonProperty("last_modified")]
+        public DateTime? LastModified { get; set; }
+    }
+}

--- a/Kentico.Kontent.Management/Models/Assets/AssetModel.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetModel.cs
@@ -69,5 +69,21 @@ namespace Kentico.Kontent.Management.Models.Assets
         /// </summary>
         [JsonProperty("last_modified")]
         public DateTime? LastModified { get; set; }
+
+        /// <summary>
+        /// Image Height
+        /// </summary>
+        [JsonProperty("image_height")]
+        public int? ImageHeight { get; set; }
+        /// <summary>
+        /// Image WIdth
+        /// </summary>
+        [JsonProperty("image_width")]
+        public int? ImageWidth { get; set; }
+        /// <summary>
+        /// The referenced folder's ID. Not present if the asset is not in a folder.
+        /// </summary>
+        [JsonProperty("folder")]
+        public AssetFolder Folder { get; set; }
     }
 }

--- a/Kentico.Kontent.Management/Models/Assets/AssetUpdateModel.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetUpdateModel.cs
@@ -20,5 +20,10 @@ namespace Kentico.Kontent.Management.Models.Assets
         /// </summary>
         [JsonProperty("title")]
         public string Title { get; set; }
+        /// <summary>
+        /// Folder of the asset. If outside of all folders use "id" : "00000000-0000-0000-0000-000000000000".
+        /// </summary>
+        [JsonProperty("folder", Required = Required.Always)]
+        public AssetFolderIdentifier Folder { get; set; }
     }
 }

--- a/Kentico.Kontent.Management/Models/Assets/AssetUpsertModel.cs
+++ b/Kentico.Kontent.Management/Models/Assets/AssetUpsertModel.cs
@@ -27,5 +27,10 @@ namespace Kentico.Kontent.Management.Models.Assets
         /// </summary>
         [JsonProperty("title")]
         public string Title { get; set; }
+        /// <summary>
+        /// Folder of the asset. If outside of all folders use "id" : "00000000-0000-0000-0000-000000000000".
+        /// </summary>
+        [JsonProperty("folder", Required = Required.Always)]
+        public AssetFolderIdentifier Folder { get; set; }
     }
 }

--- a/Kentico.Kontent.Management/Modules/ActionInvoker/ActionInvoker.cs
+++ b/Kentico.Kontent.Management/Modules/ActionInvoker/ActionInvoker.cs
@@ -59,19 +59,19 @@ namespace Kentico.Kontent.Management.Modules.ActionInvoker
             return await ReadResultAsync<TResponse>(response);
         }
 
-        public async Task<TResponse> InvokeReadOnlyMethodAsync<TResponse>(string endpointUrl, HttpMethod method)
+        public async Task<TResponse> InvokeReadOnlyMethodAsync<TResponse>(string endpointUrl, HttpMethod method, Dictionary<string, string> headers = null)
         {
-            var message = _messageCreator.CreateMessage(method, endpointUrl);
+            var message = _messageCreator.CreateMessage(method, endpointUrl, null, headers);
 
-            var response = await _cmHttpClient.SendAsync(_messageCreator, endpointUrl, method);
+            var response = await _cmHttpClient.SendAsync(_messageCreator, endpointUrl, method, null, headers);
 
             return await ReadResultAsync<TResponse>(response);
         }
 
-        public async Task InvokeMethodAsync(string endpointUrl, HttpMethod method)
+        public async Task InvokeMethodAsync(string endpointUrl, HttpMethod method, Dictionary<string, string> headers = null)
         {
-            var message = _messageCreator.CreateMessage(method, endpointUrl);
-            await _cmHttpClient.SendAsync(_messageCreator, endpointUrl, method);
+            var message = _messageCreator.CreateMessage(method, endpointUrl, null, headers);
+            await _cmHttpClient.SendAsync(_messageCreator, endpointUrl, method, null, headers);
         }
 
         public async Task<TResponse> UploadFileAsync<TResponse>(string endpointUrl, Stream stream, string contentType)

--- a/Kentico.Kontent.Management/Modules/ActionInvoker/IActionInvoker.cs
+++ b/Kentico.Kontent.Management/Modules/ActionInvoker/IActionInvoker.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -8,9 +9,9 @@ namespace Kentico.Kontent.Management.Modules.ActionInvoker
     {
         Task<TResponse> InvokeMethodAsync<TPayload, TResponse>(string endpointUrl, HttpMethod method, TPayload body);
 
-        Task<TResponse> InvokeReadOnlyMethodAsync<TResponse>(string endpointUrl, HttpMethod method);
+        Task<TResponse> InvokeReadOnlyMethodAsync<TResponse>(string endpointUrl, HttpMethod method, Dictionary<string, string> headers = null);
 
-        Task InvokeMethodAsync(string endpointUrl, HttpMethod method);
+        Task InvokeMethodAsync(string endpointUrl, HttpMethod method, Dictionary<string, string> headers = null);
 
         Task<TResponse> UploadFileAsync<TResponse>(string endpointUrl, Stream stream, string contentType);
     }

--- a/Kentico.Kontent.Management/Modules/ActionInvoker/IMessageCreator.cs
+++ b/Kentico.Kontent.Management/Modules/ActionInvoker/IMessageCreator.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Kentico.Kontent.Management.Modules.ActionInvoker
 {
@@ -13,7 +15,8 @@ namespace Kentico.Kontent.Management.Modules.ActionInvoker
         /// <param name="method">The HTTP method.</param>
         /// <param name="url">The url as a string.</param>
         /// <param name="content">The HTTP content.</param>
+        /// <param name="headers">HTTP Headers (optional).</param>
         /// <returns></returns>
-        HttpRequestMessage CreateMessage(HttpMethod method, string url, HttpContent content = null);
+        HttpRequestMessage CreateMessage(HttpMethod method, string url, HttpContent content = null, Dictionary<string,string> headers = null);
     }
 }

--- a/Kentico.Kontent.Management/Modules/ActionInvoker/MessageCreator.cs
+++ b/Kentico.Kontent.Management/Modules/ActionInvoker/MessageCreator.cs
@@ -1,4 +1,6 @@
 using Kentico.Kontent.Management.Modules.Extensions;
+using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
@@ -13,10 +15,15 @@ namespace Kentico.Kontent.Management.Modules.ActionInvoker
             _apiKey = apiKey;
         }
 
-        public HttpRequestMessage CreateMessage(HttpMethod method, string url, HttpContent content = null)
+        public HttpRequestMessage CreateMessage(HttpMethod method, string url, HttpContent content = null, Dictionary<string,string> headers = null)
         {
             var message = new HttpRequestMessage(method, url);
             message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            if (headers != null)
+            {
+                foreach (var header in headers)
+                    message.Headers.Add(header.Key, header.Value);
+            }
             message.Content = content;
             message.Headers.AddSdkTrackingHeader();
             return message;

--- a/Kentico.Kontent.Management/Modules/HttpClient/IManagementHttpClient.cs
+++ b/Kentico.Kontent.Management/Modules/HttpClient/IManagementHttpClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Kentico.Kontent.Management.Modules.ActionInvoker;
 
@@ -16,11 +18,13 @@ namespace Kentico.Kontent.Management.Modules.HttpClient
         /// <param name="endpointUrl">The url to make request to.</param>
         /// <param name="method">The HTTP method.</param>
         /// <param name="content">The HTTP content.</param>
+        /// <param name="headers">Additional http headers if needed.</param>
         /// <returns></returns>
         Task<HttpResponseMessage> SendAsync(
             IMessageCreator messageCreator,
             string endpointUrl,
             HttpMethod method,
-            HttpContent content = null);
+            HttpContent content = null,
+            Dictionary<string, string> headers = null);
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Summary
 
-:warning: **Please note that this SDK uses [Management API v1](https://docs.kontent.ai/reference/management-api-v1)**
+:warning: **Please note that this SDK uses [Management API v1](https://docs.kontent.ai/reference/management-api-v1) with the exception of the Assets API Endpoints. Those are using the V2 API.**
 
 The Kentico Kontent Management .NET SDK is a client library used for managing content in Kentico Kontent. It provides read/write access to your Kentico Kontent projects.
 


### PR DESCRIPTION
### Motivation

Which issue does this fix? 

This is a partial fix for #50. It transfers most asset V1 API interactions that existed to the V2 API and adds the Folder Listing API method. It is not a complete Asset V1 -> V2 API conversion however as it is missing these functions:

https://docs.kontent.ai/reference/management-api-v2#operation/add-asset-folders
https://docs.kontent.ai/reference/management-api-v2#operation/modify-asset-folders
https://docs.kontent.ai/reference/management-api-v2#operation/upload-a-binary-file (this one is still using the V1 API endpoint)

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- Sort of: tests need request/response static captures from Kentico's internal only project site to fit the testing scenarios. I did not include any live site data request/response captures.
- [x] Tests are passing
- Sort of: The new tests only work against my live site (which I have not included the project id or API key).
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

Update the unit tests to use your own site data and request/response mocked results.