### PR TITLE
Add renditions docu code samples into unit tests

### DIFF
--- a/Kentico.Kontent.Management.Tests/Unit/CodeSamples/CmApiV2.cs
+++ b/Kentico.Kontent.Management.Tests/Unit/CodeSamples/CmApiV2.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Kentico.Kontent.Management.Models.AssetRenditions;
 using Kentico.Kontent.Management.Models.Assets;
 using Kentico.Kontent.Management.Models.Assets.Patch;
 using Kentico.Kontent.Management.Models.Collections;
@@ -197,6 +198,41 @@ namespace Kentico.Kontent.Management.Tests.Unit.CodeSamples
             var client = _fileSystemFixture.CreateMockClientWithResponse("Assets.json");
 
             var response = await client.ListAssetsAsync();
+
+            Assert.Single(response);
+        }
+        
+        // DocSection: cm_api_v2_get_rendition
+        // Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+        [Fact]
+        public async void GetRendition()
+        {
+            var client = _fileSystemFixture.CreateMockClientWithResponse("AssetRendition.json");
+
+            var assetReference = Reference.ById(Guid.Parse("fcbb12e6-66a3-4672-85d9-d502d16b8d9c"));
+            // var assetReference = Reference.ByExternalId("which-brewing-fits-you");
+            var renditionReference = Reference.ById(Guid.Parse("ce559491-0fc1-494b-96f3-244bc095de57"));
+            // var renditionReference = Reference.ByExternalId("hero-image-rendition");
+
+            var identifier = new AssetRenditionIdentifier(assetReference, renditionReference);
+
+            var response = await client.GetAssetRenditionAsync(identifier);
+            
+            Assert.NotNull(response);
+        }
+        
+        // DocSection: cm_api_v2_get_renditions
+        // Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+        [Fact]
+        public async void GetRenditions()
+        {
+            var client = _fileSystemFixture.CreateMockClientWithResponse("AssetRenditions.json");
+
+            var assetReference = Reference.ById(Guid.Parse("fcbb12e6-66a3-4672-85d9-d502d16b8d9c"));
+            // var assetReference = Reference.ByExternalId("which-brewing-fits-you");
+
+            // Gets the first page of results
+            var response = await client.ListAssetRenditionsAsync(assetReference);
 
             Assert.Single(response);
         }
@@ -927,6 +963,33 @@ namespace Kentico.Kontent.Management.Tests.Unit.CodeSamples
 
             Assert.NotNull(response);
         }
+        
+        // DocSection: cm_api_v2_post_rendition
+        // Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+        [Fact]
+        public async void PostAssetRendition()
+        {
+            var client = _fileSystemFixture.CreateMockClientWithResponse("AssetRendition.json");
+
+            var assetReference = Reference.ById(Guid.Parse("fcbb12e6-66a3-4672-85d9-d502d16b8d9c"));
+            // var assetReference = Reference.ByExternalId("which-brewing-fits-you");
+
+            var response = await client.CreateAssetRenditionAsync(assetReference, new AssetRenditionCreateModel
+            {
+                ExternalId = "hero-image-rendition",
+                Transformation = new RectangleResizeTransformation
+                {
+                    CustomWidth = 120,
+                    CustomHeight = 240,
+                    X = 300,
+                    Y = 200,
+                    Width = 360,
+                    Height = 720,                    
+                }
+            });
+
+            Assert.NotNull(response);
+        }
 
         // DocSection: cm_api_v2_post_file
         // Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
@@ -1365,6 +1428,36 @@ namespace Kentico.Kontent.Management.Tests.Unit.CodeSamples
 
             Assert.NotNull(createdAssetResponse);
             Assert.NotNull(updatedAssetResponse);
+        }
+        
+        // DocSection: cm_api_v2_put_rendition
+        // Tip: Find more about .NET SDKs at https://kontent.ai/learn/net
+        [Fact]
+        public async void PutAssetRendition()
+        {
+            var client = _fileSystemFixture.CreateMockClientWithResponse("AssetRendition.json");
+
+            var assetReference = Reference.ById(Guid.Parse("fcbb12e6-66a3-4672-85d9-d502d16b8d9c"));
+            // var assetReference = Reference.ByExternalId("which-brewing-fits-you");
+            var renditionReference = Reference.ById(Guid.Parse("ce559491-0fc1-494b-96f3-244bc095de57"));
+            // var renditionReference = Reference.ByExternalId("hero-image-rendition");
+
+            var identifier = new AssetRenditionIdentifier(assetReference, renditionReference);
+
+            var response = await client.UpdateAssetRenditionAsync(identifier, new AssetRenditionUpdateModel()
+            {
+                Transformation = new RectangleResizeTransformation
+                {
+                    CustomWidth = 120,
+                    CustomHeight = 240,
+                    X = 300,
+                    Y = 200,
+                    Width = 360,
+                    Height = 720,                    
+                }
+            });
+
+            Assert.NotNull(response);
         }
 
         // DocSection: cm_api_v2_put_item

--- a/Kentico.Kontent.Management.Tests/Unit/Data/CodeSamples/AssetRendition.json
+++ b/Kentico.Kontent.Management.Tests/Unit/Data/CodeSamples/AssetRendition.json
@@ -1,7 +1,7 @@
 {
-  "rendition_id": "966f65b2-b395-4624-a84a-d9aa5e1864d7",
-  "asset_id": "1a510cc5-e844-4552-9f3e-b964bc966bee",
-  "external_id": "rendition-1",
+  "rendition_id": "ce559491-0fc1-494b-96f3-244bc095de57",
+  "asset_id": "fcbb12e6-66a3-4672-85d9-d502d16b8d9c",
+  "external_id": "hero-image-rendition",
   "transformation": {
     "mode": "rect",
     "fit": "clip",

--- a/Kentico.Kontent.Management.Tests/Unit/Data/CodeSamples/AssetRenditions.json
+++ b/Kentico.Kontent.Management.Tests/Unit/Data/CodeSamples/AssetRenditions.json
@@ -1,0 +1,24 @@
+﻿{
+  "asset_renditions": [
+    {
+      "rendition_id": "ce559491-0fc1-494b-96f3-244bc095de57",
+      "asset_id": "fcbb12e6-66a3-4672-85d9-d502d16b8d9c",
+      "external_id": "hero-image-rendition",
+      "transformation": {
+        "mode": "rect",
+        "fit": "clip",
+        "custom_width": 120,
+        "custom_height": 240,
+        "x": 300,
+        "y": 200,
+        "width": 360,
+        "height": 720
+      },
+      "last_modified": "2021-11-22T13:55:55.7490007Z"
+    }
+  ],
+  "pagination": {
+    "continuation_token": null,
+    "next_page": null
+  }
+}


### PR DESCRIPTION
### Motivation

#137

The code samples were added into the docu here: https://github.com/KenticoDocs/kontent-docs-samples/commit/cd533f450e58293283d9c0167e4b1d8a1db3dd74

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

No testing required
